### PR TITLE
Add MyTube protocol deep-link support with auto-search

### DIFF
--- a/github/build/installer.iss
+++ b/github/build/installer.iss
@@ -59,6 +59,11 @@ Type: files; Name: "{app}\users.data.json"
 Type: files; Name: "{app}\yt-dlp.exe"
 Type: filesandordirs; Name: "{userappdata}\MyTube"
 
+[Registry]
+Root: HKCU; Subkey: "Software\Classes\mytube"; ValueType: string; ValueName: ""; ValueData: "URL:MyTube Downloader Protocol"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\mytube"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\mytube\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\MyTube Downloader.exe,0"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\mytube\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\MyTube Downloader.exe"" ""%1"""; Flags: uninsdeletekey
+
 [Run]
 Filename: "{app}\MyTube Downloader.exe"; Description: "{cm:LaunchProgram,MyTube Downloader}"; Flags: nowait postinstall skipifsilent
-

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from threading import Thread
 from utils import *
 import traceback
 import socket
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import urlparse, parse_qs, unquote
 
 
 __version__ = Version("2.3.1")
@@ -81,26 +81,20 @@ def raiseError(msg, traceback=""):
 
 
 PENDING_SEARCH_QUERY = None
-def _extract_search_query(raw_value):
-	if not raw_value:
-		return None
-	value = unquote(str(raw_value)).strip().strip('"').strip("'")
+def extract_search_query(raw_value):
+	if not raw_value: return None
+	value = str(raw_value).strip().strip('"').strip("'")
+	value = unquote(value)
 	if value.startswith("mytube://"):
 		parsed = urlparse(value)
-		query_url = parse_qs(parsed.query).get("url", [None])[0]
-		if query_url:
-			return _extract_search_query(query_url)
-		payload = parsed.netloc + parsed.path
-		payload = payload.lstrip("/")
-		return _extract_search_query(payload)
-	if value.startswith("mytube:"):
-		return _extract_search_query(value[len("mytube:"):])
-	return value if value else None
+		query_url = parse_qs(parsed.query).get("url")
+		if query_url: return query_url[0].strip() or None
+	return value or None
 
 def load_startup_query():
 	global PENDING_SEARCH_QUERY
 	for arg in sys.argv[1:]:
-		query = _extract_search_query(arg)
+		query = extract_search_query(arg)
 		if query:
 			PENDING_SEARCH_QUERY = query
 			break

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from threading import Thread
 from utils import *
 import traceback
 import socket
+from urllib.parse import parse_qs, unquote, urlparse
 
 
 __version__ = Version("2.3.1")
@@ -77,6 +78,39 @@ def raiseError(msg, traceback=""):
 		strip_ansi(str(msg)),
 		strip_ansi(str(traceback))
 	)
+
+
+PENDING_SEARCH_QUERY = None
+def _extract_search_query(raw_value):
+	if not raw_value:
+		return None
+	value = unquote(str(raw_value)).strip().strip('"').strip("'")
+	if value.startswith("mytube://"):
+		parsed = urlparse(value)
+		query_url = parse_qs(parsed.query).get("url", [None])[0]
+		if query_url:
+			return _extract_search_query(query_url)
+		payload = parsed.netloc + parsed.path
+		payload = payload.lstrip("/")
+		return _extract_search_query(payload)
+	if value.startswith("mytube:"):
+		return _extract_search_query(value[len("mytube:"):])
+	return value if value else None
+
+def load_startup_query():
+	global PENDING_SEARCH_QUERY
+	for arg in sys.argv[1:]:
+		query = _extract_search_query(arg)
+		if query:
+			PENDING_SEARCH_QUERY = query
+			break
+
+@eel.expose
+def consume_startup_query():
+	global PENDING_SEARCH_QUERY
+	query = PENDING_SEARCH_QUERY
+	PENDING_SEARCH_QUERY = None
+	return query
 
 
 CACHED_QUERIES = {}
@@ -332,4 +366,5 @@ def run():
 
 if __name__ == "__main__":
 	eel.init(resource_path("web"))
+	load_startup_query()
 	run()

--- a/src/web/scripts/app.jsx
+++ b/src/web/scripts/app.jsx
@@ -25,6 +25,7 @@ const App = () => {
 	const [errorMsg, setErrorMsg] = React.useState(null)
 	const [errorTrace, setErrorTrace] = React.useState(null)
 	const [reloadError, setReloadError] = React.useState(false)
+	const [startupQueryHandled, setStartupQueryHandled] = React.useState(false)
 
 	React.useEffect(() => {
 		const handler = (e) => {
@@ -137,6 +138,19 @@ const App = () => {
 		setCanSearch(true)
 		setSearch("")
 	}
+
+	React.useEffect(() => {
+		if (!canSearch || startupQueryHandled) return
+		const applyStartupQuery = async () => {
+			const startupQuery = await eel.consume_startup_query()()
+			setStartupQueryHandled(true)
+			if (startupQuery && startupQuery.trim() !== "") {
+				setSearch(startupQuery)
+				onSearch(startupQuery.trim())
+			}
+		}
+		applyStartupQuery()
+	}, [canSearch, startupQueryHandled])
 
 	const processResults = results=>{
 		setShowResults(true)


### PR DESCRIPTION
### Motivation
- Allow Windows/Chrome to open custom `mytube:` links and hand their payload to the app so a clicked link (e.g. `mytube:mailto:...`, `mytube:tg://...`, or `mytube:https://...`) launches the app and automatically performs a search. 

### Description
- Register the `mytube` URL protocol in the Windows installer by adding registry entries to `github/build/installer.iss` so the installer associates `mytube:` with the application. 
- Add startup deep-link extraction in `src/main.py` by parsing `sys.argv`, unquoting and handling nested forms like `mytube://...?url=...` and `mytube:...`, storing the first found payload in `PENDING_SEARCH_QUERY`. 
- Expose `consume_startup_query()` via `eel` so the frontend can fetch and clear the pending deep-link. 
- Update the frontend `src/web/scripts/app.jsx` to fetch the startup query once when searches are enabled and automatically call the existing `onSearch(...)` flow with the extracted value. 

### Testing
- Ran `python -m py_compile src/main.py src/utils.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e7278618832f90715d1938004653)