### PR TITLE
Handle deep links in already-running single app instance

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from threading import Thread
 from utils import *
 import traceback
 import socket
+from queue import Queue, Empty
 
 
 __version__ = Version("2.3.2")
@@ -79,21 +80,79 @@ def raiseError(msg, traceback=""):
 	)
 
 
-PENDING_SEARCH_QUERY = None
+SINGLE_INSTANCE_HOST = "127.0.0.1"
+SINGLE_INSTANCE_PORT = 47621
+INSTANCE_SOCKET = None
+
+PENDING_SEARCH_QUERIES = Queue()
+
+def queue_search_query(raw_value):
+	query = extract_search_query(raw_value)
+	if not query:
+		return False
+	PENDING_SEARCH_QUERIES.put(query)
+	try:
+		eel.new_startup_query(query)
+	except Exception:
+		pass
+	return True
+
 def load_startup_query():
-	global PENDING_SEARCH_QUERY
 	for arg in sys.argv[1:]:
-		query = extract_search_query(arg)
-		if query:
-			PENDING_SEARCH_QUERY = query
+		if queue_search_query(arg):
 			break
 
 @eel.expose
 def consume_startup_query():
-	global PENDING_SEARCH_QUERY
-	query = PENDING_SEARCH_QUERY
-	PENDING_SEARCH_QUERY = None
-	return query
+	try:
+		return PENDING_SEARCH_QUERIES.get_nowait()
+	except Empty:
+		return None
+
+def forward_query_to_running_instance():
+	for arg in sys.argv[1:]:
+		query = extract_search_query(arg)
+		if not query:
+			continue
+		try:
+			with socket.create_connection((SINGLE_INSTANCE_HOST, SINGLE_INSTANCE_PORT), timeout=1) as sock:
+				sock.sendall((query + "\n").encode("utf-8"))
+			return True
+		except OSError:
+			return False
+	return True
+
+def start_single_instance_server():
+	global INSTANCE_SOCKET
+	INSTANCE_SOCKET = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+	INSTANCE_SOCKET.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+	try:
+		INSTANCE_SOCKET.bind((SINGLE_INSTANCE_HOST, SINGLE_INSTANCE_PORT))
+	except OSError:
+		return False
+
+	INSTANCE_SOCKET.listen(5)
+
+	def server_handler():
+		while True:
+			try:
+				client, _ = INSTANCE_SOCKET.accept()
+			except OSError:
+				break
+			with client:
+				try:
+					data = b""
+					while not data.endswith(b"\n"):
+						chunk = client.recv(1024)
+						if not chunk:
+							break
+						data += chunk
+					queue_search_query(data.decode("utf-8").strip())
+				except Exception:
+					continue
+
+	Thread(target=server_handler, daemon=True).start()
+	return True
 
 
 CACHED_QUERIES = {}
@@ -349,5 +408,8 @@ def run():
 
 if __name__ == "__main__":
 	eel.init(resource_path("web"))
+	if not start_single_instance_server():
+		forward_query_to_running_instance()
+		sys.exit(0)
 	load_startup_query()
 	run()

--- a/src/web/python.js
+++ b/src/web/python.js
@@ -37,3 +37,11 @@ function abort_download(id){
 	window.dispatchEvent(event)
 }
 eel.expose(abort_download)
+
+function new_startup_query(query){
+	const event = new CustomEvent("new_startup_query", { detail: {
+		query: query
+	}})
+	window.dispatchEvent(event)
+}
+eel.expose(new_startup_query)

--- a/src/web/scripts/app.jsx
+++ b/src/web/scripts/app.jsx
@@ -26,6 +26,7 @@ const App = () => {
 	const [errorTrace, setErrorTrace] = React.useState(null)
 	const [reloadError, setReloadError] = React.useState(false)
 	const [startupQueryHandled, setStartupQueryHandled] = React.useState(false)
+	const [runtimeQuery, setRuntimeQuery] = React.useState(null)
 
 	React.useEffect(() => {
 		const handler = (e) => {
@@ -138,6 +139,22 @@ const App = () => {
 		setCanSearch(true)
 		setSearch("")
 	}
+
+	React.useEffect(() => {
+		if (!runtimeQuery || !canSearch) return
+		setSearch(runtimeQuery)
+		onSearch(runtimeQuery.trim())
+		setRuntimeQuery(null)
+	}, [runtimeQuery, canSearch])
+
+	React.useEffect(() => {
+		const handler = (e) => {
+			const nextQuery = (e.detail?.query || "").trim()
+			if (nextQuery !== "") setRuntimeQuery(nextQuery)
+		}
+		window.addEventListener("new_startup_query", handler)
+		return () => window.removeEventListener("new_startup_query", handler)
+	}, [])
 
 	React.useEffect(() => {
 		if (!canSearch || startupQueryHandled) return


### PR DESCRIPTION
### Motivation
- Ensure `mytube://...` links are handled when the app is already running without launching additional instances.
- Allow runtime delivery of deep-links to the running UI and support multiple incoming links while the app is active.

### Description
- Added a single-instance IPC server in `src/main.py` listening on `127.0.0.1:47621` and a client-forwarding path so a second process forwards parsed links to the running instance and exits.
- Replaced single startup query storage with a queue `PENDING_SEARCH_QUERIES` and `queue_search_query`, and updated `consume_startup_query` to pull from the queue via `get_nowait`.
- Implemented `eel.new_startup_query` in `src/web/python.js` which dispatches a `new_startup_query` DOM event for the frontend to react to.
- Updated the React app in `src/web/scripts/app.jsx` to listen for `new_startup_query`, store runtime queries in state, and trigger `onSearch` once the UI is ready (`canSearch`).

### Testing
- Ran `python -m py_compile src/main.py src/utils.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f195b29c832f959d9518e409145f)