### PR TITLE
Fix mytube:// deep-link handoff in single-instance mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from threading import Thread
 from utils import *
 import traceback
 import socket
+from collections import deque
 
 
 __version__ = Version("2.3.2")
@@ -79,21 +80,57 @@ def raiseError(msg, traceback=""):
 	)
 
 
-PENDING_SEARCH_QUERY = None
+IPC_HOST = "127.0.0.1"
+IPC_PORT = 8091
+PENDING_SEARCH_QUERIES = deque()
+
+def push_search_query(query):
+	if query and query.strip():
+		PENDING_SEARCH_QUERIES.append(query.strip())
+
 def load_startup_query():
-	global PENDING_SEARCH_QUERY
 	for arg in sys.argv[1:]:
 		query = extract_search_query(arg)
 		if query:
-			PENDING_SEARCH_QUERY = query
+			push_search_query(query)
 			break
 
 @eel.expose
 def consume_startup_query():
-	global PENDING_SEARCH_QUERY
-	query = PENDING_SEARCH_QUERY
-	PENDING_SEARCH_QUERY = None
-	return query
+	if PENDING_SEARCH_QUERIES:
+		return PENDING_SEARCH_QUERIES.popleft()
+	return None
+
+def notify_running_instance(query, host=IPC_HOST, port=IPC_PORT):
+	try:
+		payload = query.encode("utf-8")
+		with socket.create_connection((host, port), timeout=1.0) as client:
+			client.sendall(payload)
+		return True
+	except OSError:
+		return False
+
+def start_single_instance_server(host=IPC_HOST, port=IPC_PORT):
+	def handler():
+		with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+			sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+			sock.bind((host, port))
+			sock.listen(5)
+			while True:
+				try:
+					conn, _ = sock.accept()
+				except OSError:
+					continue
+				with conn:
+					try:
+						raw = conn.recv(8192).decode("utf-8").strip()
+					except Exception:
+						raw = None
+					query = extract_search_query(raw)
+					if query:
+						push_search_query(query)
+
+	Thread(target=handler, daemon=True).start()
 
 
 CACHED_QUERIES = {}
@@ -350,4 +387,7 @@ def run():
 if __name__ == "__main__":
 	eel.init(resource_path("web"))
 	load_startup_query()
+	if PENDING_SEARCH_QUERIES and notify_running_instance(PENDING_SEARCH_QUERIES[0]):
+		sys.exit(0)
+	start_single_instance_server()
 	run()

--- a/src/web/scripts/app.jsx
+++ b/src/web/scripts/app.jsx
@@ -25,7 +25,7 @@ const App = () => {
 	const [errorMsg, setErrorMsg] = React.useState(null)
 	const [errorTrace, setErrorTrace] = React.useState(null)
 	const [reloadError, setReloadError] = React.useState(false)
-	const [startupQueryHandled, setStartupQueryHandled] = React.useState(false)
+	const pollingStartupQuery = React.useRef(false)
 
 	React.useEffect(() => {
 		const handler = (e) => {
@@ -140,17 +140,26 @@ const App = () => {
 	}
 
 	React.useEffect(() => {
-		if (!canSearch || startupQueryHandled) return
-		const applyStartupQuery = async () => {
-			const startupQuery = await eel.consume_startup_query()()
-			setStartupQueryHandled(true)
-			if (startupQuery && startupQuery.trim() !== "") {
-				setSearch(startupQuery)
-				onSearch(startupQuery.trim())
+		if (!canSearch) return
+
+		const consumePendingQuery = async () => {
+			if (pollingStartupQuery.current || !canSearch) return
+			pollingStartupQuery.current = true
+			try {
+				const startupQuery = await eel.consume_startup_query()()
+				if (startupQuery && startupQuery.trim() !== "") {
+					setSearch(startupQuery)
+					await onSearch(startupQuery.trim())
+				}
+			} finally {
+				pollingStartupQuery.current = false
 			}
 		}
-		applyStartupQuery()
-	}, [canSearch, startupQueryHandled])
+
+		consumePendingQuery()
+		const timer = setInterval(consumePendingQuery, 1200)
+		return () => clearInterval(timer)
+	}, [canSearch])
 
 	const processResults = results=>{
 		setShowResults(true)


### PR DESCRIPTION
### Motivation
- Deep links using the `mytube://` protocol were not being delivered to an already-running instance, causing duplicate windows or lost links when a second process was started. 
- The previous one-shot startup query approach could not accept links delivered after initial startup, so a robust single-instance handoff and in-app delivery mechanism was required.

### Description
- Replaced the single `PENDING_SEARCH_QUERY` slot with a FIFO queue implemented via `collections.deque` and helper `push_search_query` in `src/main.py` so multiple incoming links are buffered. 
- Added a local IPC TCP server (`start_single_instance_server`) that the primary instance starts to receive payloads from subsequent processes, parsing and enqueueing incoming `mytube://` links. 
- Added forwarding logic (`notify_running_instance`) that a second process uses on startup to send its `mytube://` query to the running instance and exit instead of launching a second UI. 
- Updated the renderer (`src/web/scripts/app.jsx`) to poll `consume_startup_query()` while idle, with a `React.useRef`-guard to avoid concurrent calls, so links delivered after startup are picked up and executed by the open window.

### Testing
- `python -m py_compile src/main.py src/utils.py` ran and succeeded. 
- A quick attempt to naively evaluate JSX with `node -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f68f44f4832f9362adfb49cba596)