### PR TITLE
Ensure taskbar progress completes on successful downloads

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -260,13 +260,17 @@ def download(downloader_id):
 	downloader = DOWNLOADERS[downloader_id]
 	downloader.FFMPEG = resource_path("ffmpeg.exe")
 	OPERATIONS[downloader_id] = 0
+	def on_success(file):
+		update_taskbar_progress(downloader_id, 100, "finish")
+		eel.finish_download(downloader_id, file)
+
 	def handler():
 		try:
 			asyncio.run(downloader(
 				SETTINGS.get("output_folder"),
 				on_progress=ProgressMyTube(downloader_id),
 				ffmpeg_progress=FFmpegProgress(downloader_id),
-				on_success=lambda f: eel.finish_download(downloader_id, f),
+				on_success=on_success,
 				on_abort=lambda:eel.abort_download(downloader_id)
 			))
 		except Exception as e:


### PR DESCRIPTION
### Motivation
- Small or single-stage downloads could leave a downloader entry in `OPERATIONS` and prevent the taskbar progress from reaching 100% because the success path did not explicitly mark the operation finished.

### Description
- Add a named `on_success` callback in `src/main.py` that calls `update_taskbar_progress(downloader_id, 100, "finish")` before `eel.finish_download(...)`, and replace the inline `lambda` with this callback to guarantee taskbar completion for all download flows.

### Testing
- Ran `python -m py_compile src/main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8293209c4832fabab86aab60f24a0)