### PR TITLE
Prevent app close while downloads are active

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img src="github/images/icon.png" width="128px">
 </p>
 <p align="center">
-    <img src="https://shields.io/badge/version-2.3.2-blue"><br>
+    <img src="https://shields.io/badge/version-2.3.3-blue"><br>
     <a href="https://github.com/SuperZombi/MyTube-GUI/releases/latest"><img src="https://shields.io/badge/⇩-Download-f9b723"></a><br/>
     <a href="#donate"><img src="https://shields.io/badge/💲-Support_Project-2ea043"></a>
 </p>

--- a/github/build/installer.iss
+++ b/github/build/installer.iss
@@ -6,8 +6,8 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{D4F2B9A2-8809-43BF-B170-9F0B52508B00}
 AppName=MyTube Downloader
-AppVersion=2.3.2
-;AppVerName=MyTube Downloader 2.3.2
+AppVersion=2.3.3
+;AppVerName=MyTube Downloader 2.3.3
 AppPublisher=Super Zombi
 AppPublisherURL=https://github.com/SuperZombi/MyTube-GUI
 AppSupportURL=https://github.com/SuperZombi/MyTube-GUI

--- a/github/build/ver.txt
+++ b/github/build/ver.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 2, 3, 2),
-    prodvers=(0, 2, 3, 2),
+    filevers=(0, 2, 3, 3),
+    prodvers=(0, 2, 3, 3),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -16,9 +16,9 @@ VSVersionInfo(
         u'040904B0',
         [
         StringStruct(u'FileDescription', u'MyTube Downloader'),
-        StringStruct(u'FileVersion', u'2.3.2'),
+        StringStruct(u'FileVersion', u'2.3.3'),
         StringStruct(u'ProductName', u'MyTube'),
-        StringStruct(u'ProductVersion', u'2.3.2')])
+        StringStruct(u'ProductVersion', u'2.3.3')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [0, 1200])])
   ]

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ import win32gui
 import win32con
 
 
-__version__ = Version("2.3.2")
+__version__ = Version("2.3.3")
 @eel.expose
 def get_app_version(): return str(__version__)
 @eel.expose

--- a/src/web/scripts/app.jsx
+++ b/src/web/scripts/app.jsx
@@ -122,6 +122,25 @@ const App = () => {
 		return () => window.removeEventListener("abort_download", handler)
 	}, [])
 
+	React.useEffect(() => {
+		const hasActiveDownloads = () => (
+			downloadItems.some(item => (
+				item.status !== "finished" &&
+				item.status !== "aborted" &&
+				item.status !== "ads"
+			))
+		)
+
+		const handleBeforeUnload = (event) => {
+			if (!hasActiveDownloads()) return
+			event.preventDefault()
+			event.returnValue = ""
+		}
+
+		window.addEventListener("beforeunload", handleBeforeUnload)
+		return () => window.removeEventListener("beforeunload", handleBeforeUnload)
+	}, [downloadItems])
+
 	const onReady = _=>{
 		setIsLoading(false)
 		setCanSearch(true)


### PR DESCRIPTION
### Motivation
- Prevent accidental closing of the application while any download is still in progress by blocking window unload when active downloads exist.

### Description
- Added a `beforeunload` handler in `src/web/scripts/app.jsx` that checks `downloadItems` and blocks closing when downloads are active.
- Consider a download active when its `status` is not `"finished"`, `"aborted"`, or `"ads"`.
- The handler uses `event.preventDefault()` and `event.returnValue = ""`, and the listener is registered/cleaned up in a `useEffect` that depends on `downloadItems`.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9106d9318832fa99f988869b518f7)